### PR TITLE
fix return type for jsonSerialize()

### DIFF
--- a/src/Wuunder/Api/Config/Config.php
+++ b/src/Wuunder/Api/Config/Config.php
@@ -33,10 +33,8 @@ abstract class Config implements \JsonSerializable
 
     /**
     * Adds together default and user input items
-    *
-    * @return array A full list of all the items that are set by user and default
     */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_merge($this->defaultFields, $this->setFields);
     }

--- a/src/Wuunder/Model/Model.php
+++ b/src/Wuunder/Model/Model.php
@@ -117,7 +117,7 @@ class Model implements \JsonSerializable
         return $result;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->data;
     }


### PR DESCRIPTION
Magento coupling failed because of this. So this will fix the return type issue.